### PR TITLE
Fix the Blackjack dynamics to correctly handle receiving an ace while having a usable ace already.

### DIFF
--- a/chapter05/blackjack.py
+++ b/chapter05/blackjack.py
@@ -132,8 +132,8 @@ def play(policy_player, initial_state=None, initial_action=None):
             break
         # if hit, get new card
         card = get_card()
-        # Keep track of the ace count. the usable_ace_player flag is insufficient alone as it is
-        # cannot distinguish between having one ace or two.
+        # Keep track of the ace count. the usable_ace_player flag is insufficient alone as it cannot
+        # distinguish between having one ace or two.
         ace_count = int(usable_ace_player)
         if card == 1:
             ace_count += 1
@@ -304,7 +304,7 @@ def figure_5_1():
     plt.close()
 
 def figure_5_2():
-    state_action_values = monte_carlo_es(500000)
+    state_action_values = monte_carlo_es(5000000)
 
     state_value_no_usable_ace = np.max(state_action_values[:, :, 0, :], axis=-1)
     state_value_usable_ace = np.max(state_action_values[:, :, 1, :], axis=-1)
@@ -363,7 +363,7 @@ def figure_5_3():
 
 
 if __name__ == '__main__':
-    figure_5_1()
+    #figure_5_1()
     figure_5_2()
-    figure_5_3()
+    #figure_5_3()
 

--- a/chapter05/blackjack.py
+++ b/chapter05/blackjack.py
@@ -49,6 +49,10 @@ def get_card():
     card = min(card, 10)
     return card
 
+# get the value of a card (11 for ace).
+def card_value(card_id):
+    return 11 if card_id == 1 else card_id
+
 # play a game
 # @policy_player: specify policy for player
 # @initial_state: [whether player has a usable Ace, sum of player's cards, one card of dealer]
@@ -73,28 +77,19 @@ def play(policy_player, initial_state=None, initial_action=None):
     if initial_state is None:
         # generate a random initial state
 
-        num_of_ace = 0
-
         # initialize cards of player
         while player_sum < 12:
             # if sum of player is less than 12, always hit
             card = get_card()
+            player_sum += card_value(card)
+            usable_ace_player = (card == 1)
 
-            # if get an Ace, use it as 11
-            if card == 1:
-                num_of_ace += 1
-                card = 11
-                usable_ace_player = True
-            player_sum += card
-
-        # if player's sum is larger than 21, he must hold at least one Ace, two Aces are possible
+        # Always use an ace as 11, unless there are two.
+        # If the player's sum is larger than 21, he must hold two aces.
         if player_sum > 21:
-            # use the Ace as 1 rather than 11
+            assert player_sum == 22
+            # use one Ace as 1 rather than 11
             player_sum -= 10
-
-            # if the player only has one Ace, then he doesn't have usable Ace any more
-            if num_of_ace == 1:
-                usable_ace_player = False
 
         # initialize cards of dealer, suppose dealer will show the first card he gets
         dealer_card1 = get_card()
@@ -109,18 +104,15 @@ def play(policy_player, initial_state=None, initial_action=None):
     state = [usable_ace_player, player_sum, dealer_card1]
 
     # initialize dealer's sum
-    dealer_sum = 0
-    if dealer_card1 == 1 and dealer_card2 != 1:
-        dealer_sum += 11 + dealer_card2
-        usable_ace_dealer = True
-    elif dealer_card1 != 1 and dealer_card2 == 1:
-        dealer_sum += dealer_card1 + 11
-        usable_ace_dealer = True
-    elif dealer_card1 == 1 and dealer_card2 == 1:
-        dealer_sum += 1 + 11
-        usable_ace_dealer = True
-    else:
-        dealer_sum += dealer_card1 + dealer_card2
+    dealer_sum = card_value(dealer_card1) + card_value(dealer_card2)
+    usable_ace_dealer = 1 in (dealer_card1, dealer_card2)
+    # if the dealer's sum is larger than 21, he must hold two aces.
+    if dealer_sum > 21:
+        assert dealer_sum == 22
+        # use one Ace as 1 rather than 11
+        dealer_sum -= 10
+    assert dealer_sum <= 21
+    assert player_sum <= 21
 
     # game starts!
 
@@ -139,17 +131,23 @@ def play(policy_player, initial_state=None, initial_action=None):
         if action == ACTION_STAND:
             break
         # if hit, get new card
-        player_sum += get_card()
+        card = get_card()
+        # Keep track of the ace count. the usable_ace_player flag is insufficient alone as it is
+        # cannot distinguish between having one ace or two.
+        ace_count = int(usable_ace_player)
+        if card == 1:
+            ace_count += 1
+        player_sum += card_value(card)
 
+        # If the player has a usable ace, use it as 1 to avoid busting and continue.
+        if player_sum > 21 and ace_count:
+                player_sum -= 10
+                ace_count -= 1
         # player busts
         if player_sum > 21:
-            # if player has a usable Ace, use it as 1 to avoid busting and continue
-            if usable_ace_player == True:
-                player_sum -= 10
-                usable_ace_player = False
-            else:
-                # otherwise player loses
-                return state, -1, player_trajectory
+            return state, -1, player_trajectory
+        assert player_sum <= 21
+        usable_ace_player = (ace_count == 1)
 
     # dealer's turn
     while True:
@@ -159,22 +157,23 @@ def play(policy_player, initial_state=None, initial_action=None):
             break
         # if hit, get a new card
         new_card = get_card()
-        if new_card == 1 and dealer_sum + 11 < 21:
-            dealer_sum += 11
-            usable_ace_dealer = True
-        else:
-            dealer_sum += new_card
+        ace_count = int(usable_ace_dealer)
+        if new_card == 1:
+            ace_count += 1
+        dealer_sum += card_value(new_card)
         # dealer busts
         if dealer_sum > 21:
-            if usable_ace_dealer == True:
+            if ace_count:
             # if dealer has a usable Ace, use it as 1 to avoid busting and continue
                 dealer_sum -= 10
-                usable_ace_dealer = False
+                ace_count -= 1
             else:
             # otherwise dealer loses
                 return state, 1, player_trajectory
+        usable_ace_dealer = (ace_count == 1)
 
     # compare the sum between player and dealer
+    assert player_sum <= 21 and dealer_sum <= 21
     if player_sum > dealer_sum:
         return state, 1, player_trajectory
     elif player_sum == dealer_sum:

--- a/chapter05/blackjack.py
+++ b/chapter05/blackjack.py
@@ -138,9 +138,8 @@ def play(policy_player, initial_state=None, initial_action=None):
         if card == 1:
             ace_count += 1
         player_sum += card_value(card)
-
         # If the player has a usable ace, use it as 1 to avoid busting and continue.
-        if player_sum > 21 and ace_count:
+        while player_sum > 21 and ace_count:
                 player_sum -= 10
                 ace_count -= 1
         # player busts
@@ -161,15 +160,13 @@ def play(policy_player, initial_state=None, initial_action=None):
         if new_card == 1:
             ace_count += 1
         dealer_sum += card_value(new_card)
-        # dealer busts
-        if dealer_sum > 21:
-            if ace_count:
-            # if dealer has a usable Ace, use it as 1 to avoid busting and continue
+        # If the dealer has a usable ace, use it as 1 to avoid busting and continue.
+        while dealer_sum > 21 and ace_count:
                 dealer_sum -= 10
                 ace_count -= 1
-            else:
-            # otherwise dealer loses
-                return state, 1, player_trajectory
+        # dealer busts
+        if dealer_sum > 21:
+            return state, 1, player_trajectory
         usable_ace_dealer = (ace_count == 1)
 
     # compare the sum between player and dealer

--- a/chapter05/blackjack.py
+++ b/chapter05/blackjack.py
@@ -301,7 +301,7 @@ def figure_5_1():
     plt.close()
 
 def figure_5_2():
-    state_action_values = monte_carlo_es(5000000)
+    state_action_values = monte_carlo_es(500000)
 
     state_value_no_usable_ace = np.max(state_action_values[:, :, 0, :], axis=-1)
     state_value_usable_ace = np.max(state_action_values[:, :, 1, :], axis=-1)
@@ -360,7 +360,7 @@ def figure_5_3():
 
 
 if __name__ == '__main__':
-    #figure_5_1()
+    figure_5_1()
     figure_5_2()
-    #figure_5_3()
+    figure_5_3()
 


### PR DESCRIPTION
Updated Chapter 5's Blackjack dynamics to correctly handing the situation where the player or dealer receives an ace while already having a usable ace.

Also simplified some of the state initialization.

The reasoning for changing the ace handling logic is as follows:
If a player or dealer hits and receives an ace while already possessing an ace, it is possible that the new sum requires either one or both aces to act as a 1.

Case 1
In the case where only one ace is treated as a 1, the player or dealer still maintains a single usable ace. This was not handled correctly before (0 usable aces would be present after one of the two aces was treated as a 1).

Case 2
In the edge case where (lets say for the player) sum = 21, usable_ace = True and the player receives an ace from a hit (obviously a bad idea), a bust should not occur. The correct resulting sum should be: 21 + 11 - 10 - 10 = 12. This was treated as a bust before.

