### PR TITLE
Made the epsilon-greedy bandit algorithm break ties at random.

### DIFF
--- a/chapter02/ten_armed_testbed.py
+++ b/chapter02/ten_armed_testbed.py
@@ -48,7 +48,7 @@ class Bandit:
         # # of chosen times for each action
         self.action_count = np.zeros(self.k)
 
-        self.best_action = np.argmax(self.q_true)
+        self.best_action = np.argmax(self.q_true) 
 
     # get an action for this bandit
     def act(self):
@@ -66,7 +66,8 @@ class Bandit:
             self.action_prob = exp_est / np.sum(exp_est)
             return np.random.choice(self.indices, p=self.action_prob)
 
-        return np.argmax(self.q_estimation)
+        q_best = np.max(self.q_estimation)
+        return np.random.choice([action for action, q in enumerate(self.q_estimation) if q == q_best])
 
     # take an action, update estimation for this action
     def step(self, action):


### PR DESCRIPTION
The epsilon-greedy bandit algorithm always selects the first action with max value estimation when it’s in greedy mode whereas every other algorithm implemented here breaks ties at random. Isn't it better to have them behave identically in such cases to ensure a more fair comparison? 

Just a minor issue, it may not affect the results much, though.

Thanks.