### PR TITLE
Fix usable_ace_player bug, fix indention error, set POLICY_PLAYER dty…

### DIFF
--- a/chapter05/blackjack.py
+++ b/chapter05/blackjack.py
@@ -20,7 +20,7 @@ ACTION_STAND = 1  #  "strike" in the book
 ACTIONS = [ACTION_HIT, ACTION_STAND]
 
 # policy for player
-POLICY_PLAYER = np.zeros(22)
+POLICY_PLAYER = np.zeros(22, dtype=np.int)
 for i in range(12, 20):
     POLICY_PLAYER[i] = ACTION_HIT
 POLICY_PLAYER[20] = ACTION_STAND
@@ -77,21 +77,18 @@ def play(policy_player, initial_state=None, initial_action=None):
     if initial_state is None:
         # generate a random initial state
 
-        # initialize cards of player
-        cards = []
         while player_sum < 12:
             # if sum of player is less than 12, always hit
             card = get_card()
-            cards.append(card)
             player_sum += card_value(card)
-        usable_ace_player = (1 in cards)
 
-        # Always use an ace as 11, unless there are two.
-        # If the player's sum is larger than 21, he must hold two aces.
-        if player_sum > 21:
-            assert player_sum == 22
-            # use one Ace as 1 rather than 11
-            player_sum -= 10
+            # If the player's sum is larger than 21, he may hold one or two aces.
+            if player_sum > 21:
+                assert player_sum == 22
+                # last card must be ace
+                player_sum -= 10
+            else:
+                usable_ace_player |= (1 == card)
 
         # initialize cards of dealer, suppose dealer will show the first card he gets
         dealer_card1 = get_card()
@@ -142,8 +139,8 @@ def play(policy_player, initial_state=None, initial_action=None):
         player_sum += card_value(card)
         # If the player has a usable ace, use it as 1 to avoid busting and continue.
         while player_sum > 21 and ace_count:
-                player_sum -= 10
-                ace_count -= 1
+            player_sum -= 10
+            ace_count -= 1
         # player busts
         if player_sum > 21:
             return state, -1, player_trajectory
@@ -164,8 +161,8 @@ def play(policy_player, initial_state=None, initial_action=None):
         dealer_sum += card_value(new_card)
         # If the dealer has a usable ace, use it as 1 to avoid busting and continue.
         while dealer_sum > 21 and ace_count:
-                dealer_sum -= 10
-                ace_count -= 1
+            dealer_sum -= 10
+            ace_count -= 1
         # dealer busts
         if dealer_sum > 21:
             return state, 1, player_trajectory


### PR DESCRIPTION
``` python
        # initialize cards of player
        cards = []
        while player_sum < 12:
            # if sum of player is less than 12, always hit
            card = get_card()
            cards.append(card)
            player_sum += card_value(card)
        usable_ace_player = (1 in cards)

        # Always use an ace as 11, unless there are two.
        # If the player's sum is larger than 21, he must hold two aces.
        if player_sum > 21:
            assert player_sum == 22
            # use one Ace as 1 rather than 11
            player_sum -= 10
```

After initializing, cards of player may be [2, 9, 1], thus player_sum is 12, and the last ace is valued as 1, while usable_ace_player is True, which should be False.

