### PR TITLE
docs: fix simple typo, resoultion -> resolution

### DIFF
--- a/chapter08/maze.py
+++ b/chapter08/maze.py
@@ -89,7 +89,7 @@ class Maze:
         self.resolution = 1
 
     # extend a state to a higher resolution maze
-    # @state: state in lower resoultion maze
+    # @state: state in lower resolution maze
     # @factor: extension factor, one state will become factor^2 states after extension
     def extend_state(self, state, factor):
         new_state = [state[0] * factor, state[1] * factor]


### PR DESCRIPTION
There is a small typo in chapter08/maze.py.

Should read `resolution` rather than `resoultion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md