### PR TITLE
(fix): ten_armed_testbed.py np.float

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# Reinforcement Learning: An Introduction
+# Reinforcement Learning: An Introduction for Iranian and Persian/Farsi speakers
 
-```diff
-@@ I am looking for self-motivated students interested in RL at different levels! @@
-@@ Visit https://shangtongzhang.github.io/people/ for more details. @@
-```
+This is a forked repo from [ShangtongZhang](https://github.com/ShangtongZhang/reinforcement-learning-an-introduction).
 
-[![Build Status](https://travis-ci.org/ShangtongZhang/reinforcement-learning-an-introduction.svg?branch=master)](https://travis-ci.org/ShangtongZhang/reinforcement-learning-an-introduction)
+I customized the README and updated some codes because of old versions of dependent libraries; And It's a free course for reinforcement learning enthusiastic which is gathered and prepared by [Prof. Mohammad Hossein Rezvani](https://scholar.google.com/citations?user=6RWTlo0AAAAJ&hl=en) for Persian speakers.
+
+The Full series of Reinforcement Learning videos (Theoretical section which is provided by PhD students of (QIAU) Qazvin Islamic Azad University and University of Tehran, etc. and reviewing code implementations by me at the end of each episodes) are available on the channel of [Prof. Mohammad Hossein Rezvani](https://youtu.be/fNVL7jBWBZI) YouTube channel.
 
 Python replication for Sutton & Barto's book [*Reinforcement Learning: An Introduction (2nd Edition)*](http://incompleteideas.net/book/the-book-2nd.html)
 

--- a/chapter02/ten_armed_testbed.py
+++ b/chapter02/ten_armed_testbed.py
@@ -209,10 +209,10 @@ def figure_2_6(runs=2000, time=1000):
                   lambda alpha: Bandit(gradient=True, step_size=alpha, gradient_baseline=True),
                   lambda coef: Bandit(epsilon=0, UCB_param=coef, sample_averages=True),
                   lambda initial: Bandit(epsilon=0, initial=initial, step_size=0.1)]
-    parameters = [np.arange(-7, -1, dtype=np.float),
-                  np.arange(-5, 2, dtype=np.float),
-                  np.arange(-4, 3, dtype=np.float),
-                  np.arange(-2, 3, dtype=np.float)]
+    parameters = [np.arange(-7, -1, dtype=float),
+                  np.arange(-5, 2, dtype=float),
+                  np.arange(-4, 3, dtype=float),
+                  np.arange(-2, 3, dtype=float)]
 
     bandits = []
     for generator, parameter in zip(generators, parameters):


### PR DESCRIPTION
np.float was originally deprecated in NumPy 1.20
Error: 
> AttributeError: module 'numpy' has no attribute 'float'. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.